### PR TITLE
Code Block Format for Shell Instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Default mode is binary delivery now. This means HDPAppStudio is an Ambari View o
 Having said that property-files are still ok. In fact the Ambari view takes your input and creates a property-file from them.
 
 To build HDP AppStudio run the following commands on a 2.2 Sandbox or cluster:
-```$ mvn clean compile assembly:single
+```
+$ mvn clean compile assembly:single
 $ cd StormTopology
 $ mvn clean compile assembly:single
 $ cd ..
@@ -27,7 +28,8 @@ and run:
 Afterwards find your HDPAppStudio View in Ambari and create your application there. 
  
 Alternatively you start a fresh sandbox, logon and do:
-```$ git clone https://github.com/digitalemil/HDPAppStudio.git
+```
+$ git clone https://github.com/digitalemil/HDPAppStudio.git
 $ cd HDPAppStudio
 $ sh ./install.sh
 ```

--- a/README.md
+++ b/README.md
@@ -9,26 +9,26 @@ Now supporting HDP 2.2.0-2041 (2.2 Preview sandbox does not work!)
 Default mode is binary delivery now. This means HDPAppStudio is an Ambari View on it's own. 
 Having said that property-files are still ok. In fact the Ambari view takes your input and creates a property-file from them.
 
-To build HDP AppStudio run the following commands on a 2.2 Sandbox or cluster
-mvn clean compile assembly:single
-cd StormTopology
-mvn clean compile assembly:single
-cd ..
-./createpkg.sh
+To build HDP AppStudio run the following commands on a 2.2 Sandbox or cluster:
+    $ mvn clean compile assembly:single
+    $ cd StormTopology
+    $ mvn clean compile assembly:single
+    $ cd ..
+    $ ./createpkg.sh
 
-This will produce a tar-ball under dist.
+This will produce a tar-ball under ``dist/``.
 
 Copy the tar-ball dist/HDPAppStudio-bin-2.2.0.0-2041.tar on the a fresh Sandbox
-and 
-tar xf HDPAppStudio-bin-2.2.0.0-2041.tar
-./install.sh
+and run: 
+    $ tar xf HDPAppStudio-bin-2.2.0.0-2041.tar
+    $ ./install.sh
 
 Afterwards find your HDPAppStudio View in Ambari and create your application there. 
  
 Alternatively you start a fresh sandbox, logon and do:
-git clone https://github.com/digitalemil/HDPAppStudio.git
-cd HDPAppStudio
-sh ./install.sh
+    $ git clone https://github.com/digitalemil/HDPAppStudio.git
+    $ cd HDPAppStudio
+    $ sh ./install.sh
 and follow the output
 
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ Default mode is binary delivery now. This means HDPAppStudio is an Ambari View o
 Having said that property-files are still ok. In fact the Ambari view takes your input and creates a property-file from them.
 
 To build HDP AppStudio run the following commands on a 2.2 Sandbox or cluster:
-    $ mvn clean compile assembly:single
-    $ cd StormTopology
-    $ mvn clean compile assembly:single
-    $ cd ..
-    $ ./createpkg.sh
+```$ mvn clean compile assembly:single
+$ cd StormTopology
+$ mvn clean compile assembly:single
+$ cd ..
+$ ./createpkg.sh
+```
 
 This will produce a tar-ball under ``dist/``.
 
@@ -26,9 +27,10 @@ and run:
 Afterwards find your HDPAppStudio View in Ambari and create your application there. 
  
 Alternatively you start a fresh sandbox, logon and do:
-    $ git clone https://github.com/digitalemil/HDPAppStudio.git
-    $ cd HDPAppStudio
-    $ sh ./install.sh
+```$ git clone https://github.com/digitalemil/HDPAppStudio.git
+$ cd HDPAppStudio
+$ sh ./install.sh
+```
 and follow the output
 
 


### PR DESCRIPTION
Updated README.md to format shell instructions in code block format.
